### PR TITLE
Feature/dgraph v20.11.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   zero:
-    image: dgraph/dgraph:v20.03.3
+    image: dgraph/dgraph:v20.11.0
     volumes:
       - type: volume
         source: dgraph
@@ -14,7 +14,7 @@ services:
     restart: on-failure
     command: dgraph zero --my=zero:5080
   server:
-    image: dgraph/dgraph:v20.03.3
+    image: dgraph/dgraph:v20.11.0
     volumes:
       - type: volume
         source: dgraph
@@ -25,9 +25,9 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=server:7080 --lru_mb=2048 --zero=zero:5080
+    command: dgraph alpha --whitelist 0.0.0.0/0 --my=server:7080 --lru_mb=2048 --zero=zero:5080
   ratel:
-    image: dgraph/dgraph:v20.03.3
+    image: dgraph/dgraph:v20.11.0
     volumes:
       - type: volume
         source: dgraph

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --whitelist 0.0.0.0/0 --my=server:7080 --lru_mb=2048 --zero=zero:5080
+    command: dgraph alpha --auth_token=${DGRAPH_AUTH_TOKEN} --whitelist 0.0.0.0/0 --my=server:7080 --lru_mb=2048 --zero=zero:5080
   ratel:
     image: dgraph/dgraph:v20.11.0
     volumes:


### PR DESCRIPTION
Updates dgraph to v20.11.0 and sets up adds two new options to the `dgraph alpha` command:
* `--whitelist 0.0.0.0/0` enables any ip to make requests to admin routes 
* `--auth_token=${DGRAPH_AUTH_TOKEN}` requires an auth token to be sent in a header on any request to admin routes.


See https://dgraph.io/docs/deploy/dgraph-administration/#securing-alter-operations