### PR TITLE
updates dgraph version to 21.03.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   zero:
-    image: dgraph/dgraph:v20.11.0
+    image: dgraph/dgraph:v21.03.0
     volumes:
       - type: volume
         source: dgraph
@@ -14,7 +14,7 @@ services:
     restart: on-failure
     command: dgraph zero --my=zero:5080
   server:
-    image: dgraph/dgraph:v20.11.0
+    image: dgraph/dgraph:v21.03.0
     volumes:
       - type: volume
         source: dgraph
@@ -25,18 +25,7 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --auth_token=${DGRAPH_AUTH_TOKEN} --whitelist 0.0.0.0/0 --my=server:7080 --lru_mb=2048 --zero=zero:5080
-  ratel:
-    image: dgraph/dgraph:v20.11.0
-    volumes:
-      - type: volume
-        source: dgraph
-        target: /dgraph
-        volume:
-          nocopy: true
-    ports:
-      - 8000:8000
-    command: dgraph-ratel
+    command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=server:7080 --zero=zero:5080
 
 volumes:
   dgraph:


### PR DESCRIPTION
This PR updates the DGraph version to 21.03.0

Of note are the changes in the command for DGraph Alpha - particularly the change in the security options and the removal of `--lru_mb=2048`

In addition DGraph Ratel has been removed from the Docker release in 21.03.0 so is subsequently removed from this repo 
