### PR TITLE
Security flags described correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=server:7080 --zero=zero:5080
+    command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN};whitelist=0.0.0.0/0 --my=server:7080 --zero=zero:5080
 
 volumes:
   dgraph:


### PR DESCRIPTION
This PR sets the security flag correctly by delimiting token and whitelist with a semicolon rather than having them separated into distinct options