### PR TITLE
DGraph version bump

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   zero:
-    image: dgraph/dgraph:v21.03.0
+    image: dgraph/dgraph:v21.03.0-12-g44005bc82
     volumes:
       - type: volume
         source: dgraph
@@ -14,7 +14,7 @@ services:
     restart: on-failure
     command: dgraph zero --my=zero:5080
   server:
-    image: dgraph/dgraph:v21.03.0
+    image: dgraph/dgraph:v21.03.0-12-g44005bc82
     volumes:
       - type: volume
         source: dgraph


### PR DESCRIPTION
bumps dgraph version (to v21.03.0-12-g44005bc82) whilst waiting for this fix -> dgraph-io/dgraph@00ada83 to land on main tag